### PR TITLE
Fix import path in README for index.js file

### DIFF
--- a/README.md
+++ b/README.md
@@ -420,7 +420,7 @@ import {
   telegram,
   twitter,
   yourlogo,
-} from "../../public/assets";
+} from "../assets";
 
 export const navigation = [
   {


### PR DESCRIPTION
This pull request addresses a discrepancy in the README file where the import path for the ../../public/assets directory on line 37 is incorrectly specified. The actual import path in the corresponding index.js file is ../assets. This correction ensures that users following the tutorial will encounter accurate information in the README, promoting a smoother learning experience. The change has been verified in the code, aligning the documentation with the correct import path.