### PR TITLE
Corrected the Git Clone URL in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ Make sure you have the following installed on your machine:
 **Cloning the Repository**
 
 ```bash
-git clone https://github.com/JavaScript-Mastery-Pro/brainwave.git
+git clone https://github.com/adrianhajdin/brainwave.git
 cd brainwave
 ```
 


### PR DESCRIPTION
*Description*:


In the `README.md` file, the git clone URL is incorrect. The current line is:

```bash
git clone https://github.com/JavaScript-Mastery-Pro/brainwave.git
````

It should be corrected to:

```bash
git clone https://github.com/adrianhajdin/brainwave.git
```

Please update the `README.md` file with the correct URL.